### PR TITLE
Allow to use with numo-narray-0.9.1.0

### DIFF
--- a/numo-linalg.gemspec
+++ b/numo-linalg.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 0"
-  spec.add_runtime_dependency "numo-narray", "~> 0.9.0.7"
+  spec.add_runtime_dependency "numo-narray", "~> 0.9.0"
 end


### PR DESCRIPTION
This change is needed to use with the latest numo-narray (0.9.1.0).